### PR TITLE
BattleEvents pipeline primitive

### DIFF
--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -1,0 +1,6 @@
+{
+  "dirs": ["res://tests/"],
+  "include_subdirs": true,
+  "prefix": "test_",
+  "suffix": ".gd"
+}

--- a/core/battle/battle_event.gd
+++ b/core/battle/battle_event.gd
@@ -1,0 +1,5 @@
+class_name BattleEvent
+extends RefCounted
+
+
+var cancelled: bool = false

--- a/core/battle/battle_event.gd.uid
+++ b/core/battle/battle_event.gd.uid
@@ -1,0 +1,1 @@
+uid://idkil6lni270

--- a/core/battle/battle_events.gd
+++ b/core/battle/battle_events.gd
@@ -1,0 +1,36 @@
+class_name BattleEvents
+extends Node
+
+
+var _subscriptions: Array[Dictionary] = []
+
+
+func subscribe(event_class: Script, listener: Callable, priority: int) -> EventSubscription:
+	var handle: EventSubscription = EventSubscription.new()
+	_subscriptions.append({
+		"event_class": event_class,
+		"listener": listener,
+		"priority": priority,
+		"handle": handle,
+	})
+	return handle
+
+
+func dispatch(event: BattleEvent) -> BattleEvent:
+	var ordered: Array[Dictionary] = _subscriptions.duplicate()
+	ordered.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		var pa: int = a["priority"]
+		var pb: int = b["priority"]
+		return pa < pb)
+	for entry: Dictionary in ordered:
+		if event.cancelled:
+			break
+		var handle: EventSubscription = entry["handle"]
+		if not handle.is_active:
+			continue
+		var event_class: Script = entry["event_class"]
+		if not is_instance_of(event, event_class):
+			continue
+		var listener: Callable = entry["listener"]
+		listener.call(event)
+	return event

--- a/core/battle/battle_events.gd.uid
+++ b/core/battle/battle_events.gd.uid
@@ -1,0 +1,1 @@
+uid://cu1fu7wkrco5n

--- a/core/battle/event_subscription.gd
+++ b/core/battle/event_subscription.gd
@@ -1,0 +1,9 @@
+class_name EventSubscription
+extends RefCounted
+
+
+var is_active: bool = true
+
+
+func release() -> void:
+	is_active = false

--- a/core/battle/event_subscription.gd.uid
+++ b/core/battle/event_subscription.gd.uid
@@ -1,0 +1,1 @@
+uid://crx6tlyffblqn

--- a/tests/battle/test_battle_events.gd
+++ b/tests/battle/test_battle_events.gd
@@ -1,0 +1,180 @@
+extends GutTest
+
+
+class DamageEvent:
+	extends BattleEvent
+	var amount: int = 0
+
+
+class TurnEndedEvent:
+	extends BattleEvent
+
+
+func test_dispatch_invokes_subscribed_listener_with_the_event() -> void:
+	var bus: BattleEvents = BattleEvents.new()
+	add_child_autofree(bus)
+
+	var received: Array[BattleEvent] = []
+	var listener: Callable = func(event: BattleEvent) -> void:
+		received.append(event)
+
+	var _sub: EventSubscription = bus.subscribe(BattleEvent, listener, 0)
+
+	var dispatched: BattleEvent = BattleEvent.new()
+	bus.dispatch(dispatched)
+
+	assert_eq(received.size(), 1, "listener should fire exactly once per dispatch")
+	assert_same(received[0], dispatched, "listener should receive the dispatched event instance")
+
+
+func test_subscribers_run_in_ascending_priority_regardless_of_registration_order() -> void:
+	var bus: BattleEvents = BattleEvents.new()
+	add_child_autofree(bus)
+
+	var call_order: Array[String] = []
+	var high_listener: Callable = func(_event: BattleEvent) -> void:
+		call_order.append("high")
+	var low_listener: Callable = func(_event: BattleEvent) -> void:
+		call_order.append("low")
+	var mid_listener: Callable = func(_event: BattleEvent) -> void:
+		call_order.append("mid")
+
+	var _high: EventSubscription = bus.subscribe(BattleEvent, high_listener, 100)
+	var _low: EventSubscription = bus.subscribe(BattleEvent, low_listener, 1)
+	var _mid: EventSubscription = bus.subscribe(BattleEvent, mid_listener, 50)
+
+	bus.dispatch(BattleEvent.new())
+
+	assert_eq(call_order, ["low", "mid", "high"] as Array[String], "subscribers should run lowest priority first")
+
+
+func test_earlier_subscriber_mutations_are_visible_to_later_subscribers() -> void:
+	var bus: BattleEvents = BattleEvents.new()
+	add_child_autofree(bus)
+
+	var observed: Array[int] = []
+	var doubler: Callable = func(event: BattleEvent) -> void:
+		var dmg: DamageEvent = event
+		dmg.amount *= 2
+	var observer: Callable = func(event: BattleEvent) -> void:
+		var dmg: DamageEvent = event
+		observed.append(dmg.amount)
+
+	var _doubler: EventSubscription = bus.subscribe(DamageEvent, doubler, 1)
+	var _observer: EventSubscription = bus.subscribe(DamageEvent, observer, 2)
+
+	var event: DamageEvent = DamageEvent.new()
+	event.amount = 5
+	bus.dispatch(event)
+
+	assert_eq(observed, [10] as Array[int], "later subscriber should see amount mutated by earlier subscriber")
+
+
+func test_setting_cancelled_short_circuits_remaining_subscribers() -> void:
+	var bus: BattleEvents = BattleEvents.new()
+	add_child_autofree(bus)
+
+	var ran: Array[String] = []
+	var first: Callable = func(_e: BattleEvent) -> void:
+		ran.append("first")
+	var canceller: Callable = func(e: BattleEvent) -> void:
+		ran.append("canceller")
+		e.cancelled = true
+	var should_not_run: Callable = func(_e: BattleEvent) -> void:
+		ran.append("should_not_run")
+
+	var _a: EventSubscription = bus.subscribe(BattleEvent, first, 1)
+	var _b: EventSubscription = bus.subscribe(BattleEvent, canceller, 2)
+	var _c: EventSubscription = bus.subscribe(BattleEvent, should_not_run, 3)
+
+	bus.dispatch(BattleEvent.new())
+
+	assert_eq(ran, ["first", "canceller"] as Array[String], "subscribers after a cancelling subscriber should not run")
+
+
+func test_released_subscription_does_not_fire_on_subsequent_dispatch() -> void:
+	var bus: BattleEvents = BattleEvents.new()
+	add_child_autofree(bus)
+
+	var hits: Array[int] = []
+	var listener: Callable = func(_e: BattleEvent) -> void:
+		hits.append(1)
+
+	var sub: EventSubscription = bus.subscribe(BattleEvent, listener, 0)
+
+	bus.dispatch(BattleEvent.new())
+	assert_eq(hits.size(), 1, "listener should fire on first dispatch")
+
+	sub.release()
+	bus.dispatch(BattleEvent.new())
+	assert_eq(hits.size(), 1, "listener should not fire after its handle was released")
+
+
+func test_releasing_a_group_of_handles_detaches_all_listeners() -> void:
+	var bus: BattleEvents = BattleEvents.new()
+	add_child_autofree(bus)
+
+	var hits: Array[String] = []
+	var a_listener: Callable = func(_e: BattleEvent) -> void:
+		hits.append("a")
+	var b_listener: Callable = func(_e: BattleEvent) -> void:
+		hits.append("b")
+
+	var group: Array[EventSubscription] = [
+		bus.subscribe(BattleEvent, a_listener, 1),
+		bus.subscribe(BattleEvent, b_listener, 2),
+	]
+
+	bus.dispatch(BattleEvent.new())
+	assert_eq(hits, ["a", "b"] as Array[String], "both listeners fire before release")
+
+	for handle: EventSubscription in group:
+		handle.release()
+
+	bus.dispatch(BattleEvent.new())
+	assert_eq(hits, ["a", "b"] as Array[String], "no listeners fire after group release")
+
+
+func test_subscriber_only_fires_for_its_registered_event_class() -> void:
+	var bus: BattleEvents = BattleEvents.new()
+	add_child_autofree(bus)
+
+	var damage_hits: Array[int] = []
+	var turn_ended_hits: Array[int] = []
+	var damage_listener: Callable = func(_e: BattleEvent) -> void:
+		damage_hits.append(1)
+	var turn_ended_listener: Callable = func(_e: BattleEvent) -> void:
+		turn_ended_hits.append(1)
+
+	var _d: EventSubscription = bus.subscribe(DamageEvent, damage_listener, 0)
+	var _t: EventSubscription = bus.subscribe(TurnEndedEvent, turn_ended_listener, 0)
+
+	bus.dispatch(DamageEvent.new())
+	bus.dispatch(TurnEndedEvent.new())
+
+	assert_eq(damage_hits.size(), 1, "DamageEvent subscriber should fire only for DamageEvent dispatches")
+	assert_eq(turn_ended_hits.size(), 1, "TurnEndedEvent subscriber should fire only for TurnEndedEvent dispatches")
+
+
+func test_non_mutating_subscribers_observe_the_same_payload_as_a_pure_notification_fanout() -> void:
+	var bus: BattleEvents = BattleEvents.new()
+	add_child_autofree(bus)
+
+	var observed_a: Array[int] = []
+	var observed_b: Array[int] = []
+	var observer_a: Callable = func(e: BattleEvent) -> void:
+		var dmg: DamageEvent = e
+		observed_a.append(dmg.amount)
+	var observer_b: Callable = func(e: BattleEvent) -> void:
+		var dmg: DamageEvent = e
+		observed_b.append(dmg.amount)
+
+	var _a: EventSubscription = bus.subscribe(DamageEvent, observer_a, 1)
+	var _b: EventSubscription = bus.subscribe(DamageEvent, observer_b, 2)
+
+	var event: DamageEvent = DamageEvent.new()
+	event.amount = 7
+	bus.dispatch(event)
+
+	assert_eq(observed_a, [7] as Array[int], "first observer sees the payload via the same dispatch as a notification fanout")
+	assert_eq(observed_b, [7] as Array[int], "second observer sees the same unmutated payload via the same dispatch path")

--- a/tests/battle/test_battle_events.gd.uid
+++ b/tests/battle/test_battle_events.gd.uid
@@ -1,0 +1,1 @@
+uid://dx01pavahtaqt


### PR DESCRIPTION
## Summary
- Add `BattleEvents` Node (per-battle child of the controller, no autoload), `BattleEvent` RefCounted base with `cancelled: bool`, and `EventSubscription` lifecycle handle under `core/battle/`.
- Single `dispatch` code path drives both mutating pipelines and pure notifications — subscribers run in ascending priority, may mutate the payload, may short-circuit by setting `event.cancelled = true`, and only fire for matching event classes.
- Subscriptions are released individually via `handle.release()` or as a group by iterating an `Array[EventSubscription]` (the shape future `CardInstance`/`StatusInstance` will hold).
- Add `.gutconfig.json` so `gut_cmdln.gd` recurses `tests/` by default now that tests live in subdirectories.

Closes #2.

## Test plan
- [x] `godot --headless -s addons/gut/gut_cmdln.gd -gexit` — 13/13 tests pass (8 new in `tests/battle/test_battle_events.gd`)
- [x] Tracer: subscribe + dispatch fires the listener with the dispatched event
- [x] Priority ordering: subscribers run lowest-priority-first regardless of registration order
- [x] Mutation propagation: earlier subscriber's payload mutation is visible to later subscribers
- [x] Cancellation short-circuits: setting `cancelled = true` skips remaining subscribers
- [x] Single-handle release: released handle no longer fires
- [x] Group release: iterating an array of handles and calling `release()` detaches all
- [x] Event-class filtering: a `DamageEvent` subscriber does not fire for `TurnEndedEvent` dispatches
- [x] Pipeline-as-notification equivalence: two non-mutating subscribers both observe the same payload through the same dispatch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)