### PR TITLE
Deck cycling: zones, draw 5, end-turn discard, reshuffle

### DIFF
--- a/core/battle/battle_controller.gd
+++ b/core/battle/battle_controller.gd
@@ -2,10 +2,15 @@ class_name BattleController
 extends Node
 
 
-signal end_requested
+signal battle_end_requested
+signal end_turn_requested
+
+const STARTING_HAND_SIZE: int = 5
 
 var state: BattleState
 var events: BattleEvents
+
+var _battle_end_pending: bool = false
 
 
 func _init() -> void:
@@ -16,9 +21,18 @@ func _init() -> void:
 
 func run_battle() -> void:
 	events.dispatch(BattleStartedEvent.new())
-	await end_requested
+	while not _battle_end_pending:
+		state.draw(STARTING_HAND_SIZE)
+		await end_turn_requested
+		state.discard_hand()
 	events.dispatch(BattleEndedEvent.new())
 
 
-func request_end() -> void:
-	end_requested.emit()
+func request_battle_end() -> void:
+	_battle_end_pending = true
+	end_turn_requested.emit()
+	battle_end_requested.emit()
+
+
+func request_end_turn() -> void:
+	end_turn_requested.emit()

--- a/core/battle/battle_state.gd
+++ b/core/battle/battle_state.gd
@@ -2,12 +2,71 @@ class_name BattleState
 extends RefCounted
 
 
+const HAND_SIZE_CAP: int = 10
+
 var player: Character
 var enemies: Array[Character]
 var events: BattleEvents
+
+var deck: Array[CardInstance] = []
+var hand: Array[CardInstance] = []
+var discard: Array[CardInstance] = []
+var exhaust: Array[CardInstance] = []
+
+var rng: RandomNumberGenerator = RandomNumberGenerator.new()
 
 
 func _init(starting_player: Character, starting_enemies: Array[Character], event_bus: BattleEvents) -> void:
 	player = starting_player
 	enemies = starting_enemies
 	events = event_bus
+
+
+func move_top_of_deck_to_hand() -> CardInstance:
+	var card: CardInstance = deck.pop_front()
+	hand.append(card)
+	_notify_hand_changed()
+	return card
+
+
+func discard_from_hand(card: CardInstance) -> void:
+	hand.erase(card)
+	discard.append(card)
+	_notify_hand_changed()
+
+
+func exhaust_from_hand(card: CardInstance) -> void:
+	hand.erase(card)
+	exhaust.append(card)
+	_notify_hand_changed()
+
+
+func discard_hand() -> void:
+	discard.append_array(hand)
+	hand.clear()
+	_notify_hand_changed()
+
+
+func _notify_hand_changed() -> void:
+	events.dispatch(HandChangedEvent.new())
+
+
+func draw(count: int) -> void:
+	for i: int in count:
+		if hand.size() >= HAND_SIZE_CAP:
+			return
+		if deck.is_empty():
+			reshuffle_discard_into_deck()
+		if deck.is_empty():
+			return
+		move_top_of_deck_to_hand()
+
+
+func reshuffle_discard_into_deck() -> void:
+	deck.append_array(discard)
+	discard.clear()
+	for i: int in range(deck.size() - 1, 0, -1):
+		var j: int = rng.randi_range(0, i)
+		var swap: CardInstance = deck[i]
+		deck[i] = deck[j]
+		deck[j] = swap

--- a/core/battle/hand_changed_event.gd
+++ b/core/battle/hand_changed_event.gd
@@ -1,0 +1,2 @@
+class_name HandChangedEvent
+extends BattleEvent

--- a/core/battle/hand_changed_event.gd.uid
+++ b/core/battle/hand_changed_event.gd.uid
@@ -1,0 +1,1 @@
+uid://djxq1brogtmlg

--- a/tests/battle/test_battle_controller.gd
+++ b/tests/battle/test_battle_controller.gd
@@ -1,6 +1,10 @@
 extends GutTest
 
 
+func _new_card() -> CardInstance:
+	return CardInstance.new(CardData.new())
+
+
 func _make_controller_with_battle() -> BattleController:
 	var controller: BattleController = BattleController.new()
 	add_child_autofree(controller)
@@ -8,6 +12,13 @@ func _make_controller_with_battle() -> BattleController:
 	var enemy: Character = Character.new(18)
 	controller.state = BattleState.new(player, [enemy] as Array[Character], controller.events)
 	return controller
+
+
+func _seed_deck(controller: BattleController, count: int) -> void:
+	var cards: Array[CardInstance] = []
+	for i: int in count:
+		cards.append(_new_card())
+	controller.state.deck = cards
 
 
 func test_run_battle_dispatches_battle_started_synchronously_then_awaits_end() -> void:
@@ -27,8 +38,62 @@ func test_run_battle_dispatches_battle_started_synchronously_then_awaits_end() -
 	assert_eq(started.size(), 1, "battle_started should be dispatched synchronously when run_battle starts")
 	assert_eq(ended.size(), 0, "battle_ended should not fire until end is explicitly requested")
 
+	controller.request_battle_end()
+	await wait_physics_frames(1)
 
-func test_request_end_resumes_run_battle_and_dispatches_battle_ended() -> void:
+
+func test_run_battle_draws_five_cards_into_hand_at_the_start_of_the_first_player_turn() -> void:
+	var controller: BattleController = _make_controller_with_battle()
+	_seed_deck(controller, 10)
+
+	controller.run_battle.call()
+
+	assert_eq(controller.state.hand.size(), 5, "first player turn should draw 5 cards into hand")
+	assert_eq(controller.state.deck.size(), 5, "those 5 cards should come off the top of the deck")
+
+	controller.request_battle_end()
+	await wait_physics_frames(1)
+
+
+func test_request_end_turn_discards_remaining_hand_and_starts_a_new_player_turn_with_a_fresh_draw() -> void:
+	var controller: BattleController = _make_controller_with_battle()
+	_seed_deck(controller, 12)
+
+	controller.run_battle.call()
+	assert_eq(controller.state.hand.size(), 5, "first turn should have drawn 5 cards")
+
+	controller.request_end_turn()
+	await wait_physics_frames(1)
+
+	assert_eq(controller.state.discard.size(), 5, "all 5 cards should land in discard at end of turn")
+	assert_eq(controller.state.hand.size(), 5, "the next player turn should immediately draw a fresh 5")
+	assert_eq(controller.state.deck.size(), 2, "those draws should come off the remaining deck")
+
+	controller.request_battle_end()
+	await wait_physics_frames(1)
+
+
+func test_multi_turn_cycling_drives_deck_through_hand_discard_and_reshuffle() -> void:
+	var controller: BattleController = _make_controller_with_battle()
+	controller.state.rng.seed = 1
+	_seed_deck(controller, 8)
+
+	controller.run_battle.call()
+	controller.request_end_turn()
+	await wait_physics_frames(1)
+	controller.request_end_turn()
+	await wait_physics_frames(1)
+	controller.request_end_turn()
+	await wait_physics_frames(1)
+
+	assert_eq(controller.state.hand.size() + controller.state.deck.size() + controller.state.discard.size(), 8, "every original deck card should still be accounted for somewhere")
+	assert_eq(controller.state.hand.size(), 5, "fourth player turn should have drawn a fresh 5 (with reshuffle)")
+
+	controller.request_battle_end()
+	await wait_physics_frames(1)
+
+
+func test_request_battle_end_resumes_run_battle_and_dispatches_battle_ended() -> void:
 	var controller: BattleController = _make_controller_with_battle()
 
 	var ended: Array[int] = []
@@ -37,7 +102,7 @@ func test_request_end_resumes_run_battle_and_dispatches_battle_ended() -> void:
 	var _sub: EventSubscription = controller.events.subscribe(BattleEndedEvent, on_end, 0)
 
 	controller.run_battle.call()
-	controller.request_end()
+	controller.request_battle_end()
 	await wait_physics_frames(1)
 
 	assert_eq(ended.size(), 1, "battle_ended should be dispatched once the controller is told to end")

--- a/tests/battle/test_battle_state.gd
+++ b/tests/battle/test_battle_state.gd
@@ -1,6 +1,15 @@
 extends GutTest
 
 
+func _make_battle() -> BattleState:
+	var bus: BattleEvents = BattleEvents.new()
+	add_child_autofree(bus)
+	var player: Character = Character.new(40)
+	var brute: Character = Character.new(18)
+	var trickster: Character = Character.new(12)
+	return BattleState.new(player, [brute, trickster] as Array[Character], bus)
+
+
 func test_battle_state_holds_player_enemies_and_events() -> void:
 	var bus: BattleEvents = BattleEvents.new()
 	add_child_autofree(bus)
@@ -15,3 +24,224 @@ func test_battle_state_holds_player_enemies_and_events() -> void:
 	assert_same(battle.enemies[0], brute, "BattleState should preserve enemy order")
 	assert_same(battle.enemies[1], trickster, "BattleState should preserve enemy order")
 	assert_same(battle.events, bus, "BattleState should expose the per-battle event bus")
+
+
+func test_battle_state_starts_with_four_empty_zone_piles() -> void:
+	var battle: BattleState = _make_battle()
+
+	assert_eq(battle.deck.size(), 0, "deck should start empty")
+	assert_eq(battle.hand.size(), 0, "hand should start empty")
+	assert_eq(battle.discard.size(), 0, "discard should start empty")
+	assert_eq(battle.exhaust.size(), 0, "exhaust should start empty")
+
+
+func _new_card() -> CardInstance:
+	return CardInstance.new(CardData.new())
+
+
+func test_move_top_of_deck_to_hand_pulls_first_deck_card_into_hand_and_returns_it() -> void:
+	var battle: BattleState = _make_battle()
+	var top: CardInstance = _new_card()
+	var middle: CardInstance = _new_card()
+	var bottom: CardInstance = _new_card()
+	battle.deck = [top, middle, bottom] as Array[CardInstance]
+
+	var drawn: CardInstance = battle.move_top_of_deck_to_hand()
+
+	assert_same(drawn, top, "drawing should return the top-of-deck card")
+	assert_eq(battle.hand, [top] as Array[CardInstance], "the drawn card should land in hand")
+	assert_eq(battle.deck, [middle, bottom] as Array[CardInstance], "the drawn card should be removed from the deck")
+
+
+func test_discard_from_hand_moves_card_from_hand_to_discard_pile() -> void:
+	var battle: BattleState = _make_battle()
+	var keeper: CardInstance = _new_card()
+	var played: CardInstance = _new_card()
+	battle.hand = [keeper, played] as Array[CardInstance]
+
+	battle.discard_from_hand(played)
+
+	assert_eq(battle.hand, [keeper] as Array[CardInstance], "the discarded card should be removed from hand")
+	assert_eq(battle.discard, [played] as Array[CardInstance], "the discarded card should land on the discard pile")
+
+
+func test_exhaust_from_hand_moves_card_from_hand_to_exhaust_pile() -> void:
+	var battle: BattleState = _make_battle()
+	var keeper: CardInstance = _new_card()
+	var burned: CardInstance = _new_card()
+	battle.hand = [keeper, burned] as Array[CardInstance]
+
+	battle.exhaust_from_hand(burned)
+
+	assert_eq(battle.hand, [keeper] as Array[CardInstance], "the exhausted card should be removed from hand")
+	assert_eq(battle.exhaust, [burned] as Array[CardInstance], "the exhausted card should land on the exhaust pile")
+
+
+func test_reshuffle_moves_every_discarded_card_into_the_deck_and_empties_discard() -> void:
+	var battle: BattleState = _make_battle()
+	var a: CardInstance = _new_card()
+	var b: CardInstance = _new_card()
+	var c: CardInstance = _new_card()
+	battle.discard = [a, b, c] as Array[CardInstance]
+
+	battle.reshuffle_discard_into_deck()
+
+	assert_eq(battle.discard.size(), 0, "discard should be empty after reshuffle")
+	assert_eq(battle.deck.size(), 3, "deck should contain every reshuffled card")
+	assert_true(battle.deck.has(a), "deck should contain card a after reshuffle")
+	assert_true(battle.deck.has(b), "deck should contain card b after reshuffle")
+	assert_true(battle.deck.has(c), "deck should contain card c after reshuffle")
+
+
+func test_reshuffle_is_deterministic_for_a_given_rng_seed() -> void:
+	var cards: Array[CardInstance] = [
+		_new_card(), _new_card(), _new_card(), _new_card(), _new_card(), _new_card(), _new_card(), _new_card(),
+	]
+
+	var first: BattleState = _make_battle()
+	first.rng.seed = 42
+	first.discard = cards.duplicate() as Array[CardInstance]
+	first.reshuffle_discard_into_deck()
+
+	var second: BattleState = _make_battle()
+	second.rng.seed = 42
+	second.discard = cards.duplicate() as Array[CardInstance]
+	second.reshuffle_discard_into_deck()
+
+	assert_eq(first.deck, second.deck, "the same rng seed should produce the same shuffle order")
+
+
+func test_reshuffle_actually_permutes_for_at_least_one_seed() -> void:
+	var cards: Array[CardInstance] = [
+		_new_card(), _new_card(), _new_card(), _new_card(), _new_card(), _new_card(), _new_card(), _new_card(),
+	]
+	var battle: BattleState = _make_battle()
+	battle.rng.seed = 42
+	battle.discard = cards.duplicate() as Array[CardInstance]
+
+	battle.reshuffle_discard_into_deck()
+
+	assert_ne(battle.deck, cards, "the reshuffled deck should not match the original order for seed 42")
+
+
+func test_draw_pulls_n_cards_from_top_of_deck_into_hand() -> void:
+	var battle: BattleState = _make_battle()
+	var first: CardInstance = _new_card()
+	var second: CardInstance = _new_card()
+	var third: CardInstance = _new_card()
+	var fourth: CardInstance = _new_card()
+	battle.deck = [first, second, third, fourth] as Array[CardInstance]
+
+	battle.draw(3)
+
+	assert_eq(battle.hand, [first, second, third] as Array[CardInstance], "draw should pull cards from the top of the deck in order")
+	assert_eq(battle.deck, [fourth] as Array[CardInstance], "drawn cards should be removed from the deck")
+
+
+func test_draw_stops_at_hand_size_cap_of_ten_even_if_deck_has_more() -> void:
+	var battle: BattleState = _make_battle()
+	var deck_cards: Array[CardInstance] = []
+	for i: int in 15:
+		deck_cards.append(_new_card())
+	battle.deck = deck_cards.duplicate() as Array[CardInstance]
+
+	battle.draw(15)
+
+	assert_eq(battle.hand.size(), 10, "hand should cap at the 10-card max")
+	assert_eq(battle.deck.size(), 5, "draws past the cap should not consume more deck cards")
+	for i: int in 10:
+		assert_same(battle.hand[i], deck_cards[i], "the first 10 deck cards should be the ones drawn into hand")
+
+
+func test_draw_reshuffles_discard_into_deck_when_deck_empties_mid_draw() -> void:
+	var battle: BattleState = _make_battle()
+	battle.rng.seed = 7
+	var on_top: CardInstance = _new_card()
+	var in_discard_a: CardInstance = _new_card()
+	var in_discard_b: CardInstance = _new_card()
+	battle.deck = [on_top] as Array[CardInstance]
+	battle.discard = [in_discard_a, in_discard_b] as Array[CardInstance]
+
+	battle.draw(3)
+
+	assert_eq(battle.hand.size(), 3, "draw should pull all 3 cards even though the deck only had 1")
+	assert_eq(battle.discard.size(), 0, "discard should be empty after the auto-reshuffle")
+	assert_eq(battle.deck.size(), 0, "the deck should be drained of all reshuffled cards")
+	assert_true(battle.hand.has(on_top), "the original deck card should be in hand")
+	assert_true(battle.hand.has(in_discard_a), "the first reshuffled discard card should be in hand")
+	assert_true(battle.hand.has(in_discard_b), "the second reshuffled discard card should be in hand")
+
+
+func test_draw_stops_gracefully_when_deck_and_discard_are_both_exhausted() -> void:
+	var battle: BattleState = _make_battle()
+	var only: CardInstance = _new_card()
+	battle.deck = [only] as Array[CardInstance]
+
+	battle.draw(5)
+
+	assert_eq(battle.hand, [only] as Array[CardInstance], "draw should pull every available card without erroring")
+	assert_eq(battle.deck.size(), 0, "deck should be empty after exhausting available cards")
+	assert_eq(battle.discard.size(), 0, "discard should remain empty when nothing was discarded")
+
+
+func test_discard_hand_moves_every_remaining_hand_card_to_discard_in_order() -> void:
+	var battle: BattleState = _make_battle()
+	var first: CardInstance = _new_card()
+	var second: CardInstance = _new_card()
+	var third: CardInstance = _new_card()
+	battle.hand = [first, second, third] as Array[CardInstance]
+
+	battle.discard_hand()
+
+	assert_eq(battle.hand.size(), 0, "hand should be empty after end-of-turn discard")
+	assert_eq(battle.discard, [first, second, third] as Array[CardInstance], "all cards should land on discard preserving hand order")
+
+
+func _watch_hand_changes(battle: BattleState) -> Array[BattleEvent]:
+	var received: Array[BattleEvent] = []
+	var listener: Callable = func(event: BattleEvent) -> void:
+		received.append(event)
+	var _sub: EventSubscription = battle.events.subscribe(HandChangedEvent, listener, 0)
+	return received
+
+
+func test_move_top_of_deck_to_hand_dispatches_a_hand_changed_event() -> void:
+	var battle: BattleState = _make_battle()
+	battle.deck = [_new_card()] as Array[CardInstance]
+	var observed: Array[BattleEvent] = _watch_hand_changes(battle)
+
+	battle.move_top_of_deck_to_hand()
+
+	assert_eq(observed.size(), 1, "drawing one card should dispatch exactly one HandChangedEvent")
+
+
+func test_discard_from_hand_dispatches_a_hand_changed_event() -> void:
+	var battle: BattleState = _make_battle()
+	var card: CardInstance = _new_card()
+	battle.hand = [card] as Array[CardInstance]
+	var observed: Array[BattleEvent] = _watch_hand_changes(battle)
+
+	battle.discard_from_hand(card)
+
+	assert_eq(observed.size(), 1, "discarding from hand should dispatch a HandChangedEvent")
+
+
+func test_exhaust_from_hand_dispatches_a_hand_changed_event() -> void:
+	var battle: BattleState = _make_battle()
+	var card: CardInstance = _new_card()
+	battle.hand = [card] as Array[CardInstance]
+	var observed: Array[BattleEvent] = _watch_hand_changes(battle)
+
+	battle.exhaust_from_hand(card)
+
+	assert_eq(observed.size(), 1, "exhausting from hand should dispatch a HandChangedEvent")
+
+
+func test_discard_hand_dispatches_a_single_hand_changed_event_for_the_whole_batch() -> void:
+	var battle: BattleState = _make_battle()
+	battle.hand = [_new_card(), _new_card(), _new_card()] as Array[CardInstance]
+	var observed: Array[BattleEvent] = _watch_hand_changes(battle)
+
+	battle.discard_hand()
+
+	assert_eq(observed.size(), 1, "discard_hand should dispatch exactly one HandChangedEvent for the batch")

--- a/ui/battle/battle_scene.gd
+++ b/ui/battle/battle_scene.gd
@@ -2,20 +2,26 @@ extends Control
 
 
 const STRIKE: CardData = preload("res://content/cards/strike.tres")
+const STARTER_DECK_SIZE: int = 10
 
 @onready var _controller: BattleController = $BattleController
 @onready var _player_view: CharacterView = $Stage/PlayerView
 @onready var _enemy_view: CharacterView = $Stage/EnemyView
-@onready var _strike_button: Button = $DebugBar/StrikeButton
+@onready var _end_turn_button: Button = $EndTurnButton
+@onready var _hand_view: HandView = $HandView
+@onready var _deck_count_label: Label = $DeckCount
+@onready var _discard_count_label: Label = $DiscardCount
 
 var _state: BattleState
 var _enemy: Character
+var _hand_subscription: EventSubscription
 
 
 func _ready() -> void:
 	var player: Character = Character.new(40)
 	_enemy = Character.new(18)
 	_state = BattleState.new(player, [_enemy] as Array[Character], _controller.events)
+	_state.deck = _build_starter_deck()
 	_controller.state = _state
 
 	_player_view.label_text = "Goblin (you)"
@@ -23,14 +29,48 @@ func _ready() -> void:
 	_enemy_view.label_text = "Placeholder Enemy"
 	_enemy_view.bind(_enemy, _controller.events)
 
-	_strike_button.pressed.connect(_on_strike_pressed)
+	_hand_subscription = _controller.events.subscribe(HandChangedEvent, _on_hand_changed, 0)
+	_end_turn_button.pressed.connect(_on_end_turn_pressed)
+
 	_controller.run_battle.call()
+	_hand_view.render(_state.hand)
+	_refresh_pile_counts()
 
 
-func _on_strike_pressed() -> void:
-	if _state == null:
+func _exit_tree() -> void:
+	if _hand_subscription != null:
+		_hand_subscription.release()
+		_hand_subscription = null
+	if _controller != null and is_instance_valid(_controller):
+		_controller.request_battle_end()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventKey:
+		var key_event: InputEventKey = event
+		if key_event.pressed and not key_event.echo and key_event.keycode == KEY_SPACE:
+			_on_end_turn_pressed()
+			get_viewport().set_input_as_handled()
+
+
+func _on_end_turn_pressed() -> void:
+	if _controller == null:
 		return
-	if _enemy.current_hp <= 0:
-		return
-	var card: CardInstance = CardInstance.new(STRIKE)
-	card.play(_state, _enemy)
+	_controller.request_end_turn()
+
+
+func _on_hand_changed(_event: BattleEvent) -> void:
+	_hand_view.render.call_deferred(_state.hand)
+	_refresh_pile_counts.call_deferred()
+
+
+func _refresh_pile_counts() -> void:
+	_deck_count_label.text = "Deck: %d" % _state.deck.size()
+	_discard_count_label.text = "Discard: %d" % _state.discard.size()
+
+
+func _build_starter_deck() -> Array[CardInstance]:
+	var cards: Array[CardInstance] = []
+	for i: int in STARTER_DECK_SIZE:
+		cards.append(CardInstance.new(STRIKE))
+	return cards

--- a/ui/battle/battle_scene.tscn
+++ b/ui/battle/battle_scene.tscn
@@ -1,8 +1,9 @@
-[gd_scene format=3 uid="uid://cvii3mt1lge1a"]
+[gd_scene load_steps=4 format=3 uid="uid://cvii3mt1lge1a"]
 
 [ext_resource type="Script" uid="uid://1ldedv020xmp" path="res://ui/battle/battle_scene.gd" id="1_battle_scene"]
 [ext_resource type="Script" uid="uid://cjjxakg20v6sm" path="res://core/battle/battle_controller.gd" id="2_battle_controller"]
 [ext_resource type="PackedScene" uid="uid://cfflio10r24jw" path="res://ui/battle/character_view.tscn" id="3_character_view"]
+[ext_resource type="Script" uid="uid://dikhk36w3mptk" path="res://ui/battle/hand_view.gd" id="4_hand_view"]
 
 [node name="BattleScene" type="Control"]
 layout_mode = 3
@@ -34,21 +35,62 @@ layout_mode = 2
 [node name="EnemyView" parent="Stage" instance=ExtResource("3_character_view")]
 layout_mode = 2
 
-[node name="DebugBar" type="HBoxContainer" parent="."]
+[node name="EndTurnButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -160.0
+offset_top = -16.0
+offset_right = -32.0
+offset_bottom = 24.0
+grow_horizontal = 0
+grow_vertical = 2
+text = "End Turn (Space)"
+
+[node name="DeckCount" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 24.0
+offset_top = -56.0
+offset_right = 160.0
+offset_bottom = -24.0
+grow_vertical = 0
+text = "Deck: 0"
+
+[node name="DiscardCount" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -160.0
+offset_top = -56.0
+offset_right = -24.0
+offset_bottom = -24.0
+grow_horizontal = 0
+grow_vertical = 0
+horizontal_alignment = 2
+text = "Discard: 0"
+
+[node name="HandView" type="HBoxContainer" parent="."]
 layout_mode = 1
 anchors_preset = 7
 anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
 anchor_bottom = 1.0
-offset_left = -120.0
-offset_top = -80.0
-offset_right = 120.0
+offset_left = -440.0
+offset_top = -160.0
+offset_right = 440.0
 offset_bottom = -32.0
 grow_horizontal = 2
 grow_vertical = 0
 alignment = 1
-
-[node name="StrikeButton" type="Button" parent="DebugBar"]
-layout_mode = 2
-text = "Debug: Play Strike"
+theme_override_constants/separation = 12
+script = ExtResource("4_hand_view")

--- a/ui/battle/hand_view.gd
+++ b/ui/battle/hand_view.gd
@@ -1,0 +1,22 @@
+class_name HandView
+extends HBoxContainer
+
+
+const PLACEHOLDER_SIZE: Vector2 = Vector2(80, 120)
+const PLACEHOLDER_COLOR: Color = Color(0.32, 0.45, 0.65)
+
+
+func render(hand: Array[CardInstance]) -> void:
+	for child: Node in get_children():
+		child.queue_free()
+	for card: CardInstance in hand:
+		var placeholder: ColorRect = ColorRect.new()
+		placeholder.custom_minimum_size = PLACEHOLDER_SIZE
+		placeholder.color = PLACEHOLDER_COLOR
+		var label: Label = Label.new()
+		label.text = card.data.name if card.data != null else "?"
+		label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+		label.set_anchors_preset(Control.PRESET_FULL_RECT)
+		placeholder.add_child(label)
+		add_child(placeholder)

--- a/ui/battle/hand_view.gd.uid
+++ b/ui/battle/hand_view.gd.uid
@@ -1,0 +1,1 @@
+uid://dikhk36w3mptk


### PR DESCRIPTION
Closes #4.

## Summary
- `BattleState` now owns `deck`, `hand`, `discard`, `exhaust` plus a seedable `rng`. Helpers: `move_top_of_deck_to_hand`, `discard_from_hand`, `exhaust_from_hand`, `discard_hand`, `reshuffle_discard_into_deck`, and `draw(n)` (capped at `HAND_SIZE_CAP = 10`, auto-reshuffles when the deck empties mid-draw, stops gracefully when both piles are exhausted).
- `HandChangedEvent` dispatched on every hand mutation so the UI (and future status systems) can observe without polling.
- `BattleController.run_battle` is now a turn-loop coroutine: dispatch `BattleStartedEvent` → `state.draw(5)` → `await end_turn_requested` → `state.discard_hand()` → repeat. `request_battle_end()` flips a flag and unblocks the await; `request_end_turn()` advances one turn. The previous `end_requested` signal is renamed `battle_end_requested` per plan.
- UI: `BattleScene` seeds a 10-Strike placeholder deck, wires an **End Turn** button + **Space** keybind, renders the hand as placeholder rectangles via a new `HandView`, and shows rough **Deck:** / **Discard:** count labels so the reshuffle is observable. Debug "Play Strike" button removed.
- Shuffle uses a Fisher-Yates pass over the deck via `RandomNumberGenerator`; tests set `state.rng.seed = N` for determinism.

## Test plan
- [x] GUT: `BattleState` zone-movement helpers, draw cap, auto-reshuffle on empty draw, graceful stop, `HandChangedEvent` dispatch on every mutator (incl. `discard_hand` batch as a single event).
- [x] GUT: shuffle is deterministic for a given seed, and actually permutes for at least one seed.
- [x] GUT: `BattleController.run_battle` draws 5 on the first player turn, end-turn discards + redraws, multi-turn cycling drives reshuffle, and `request_battle_end` still dispatches `BattleEndedEvent`.
- [x] Full sweep: 45/45 passing.
- [x] Manual: ran the scene, end-turn button + Space both end turns, deck/discard counts update live, reshuffle visible at end of turn 2.

## Out of scope (per #4 spec)
- Fanned hand layout (#5) — placeholder rectangles only.
- Energy / can-play (#6).
- Disable End Turn during animations (#6).
- Pile UI modal viewer (#10) — the count labels are a temporary stand-in for verification, not the final pile UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)