### PR TITLE
Energy budget: 3 per turn, can-play check, energy UI

### DIFF
--- a/content/cards/defend.tres
+++ b/content/cards/defend.tres
@@ -1,6 +1,7 @@
 [gd_resource type="Resource" script_class="CardData" format=3 uid="uid://b3defend0001"]
 
 [ext_resource type="Script" uid="uid://dj0q6jkwgu5ar" path="res://core/cards/card_data.gd" id="1_card_data"]
+[ext_resource type="Script" uid="uid://c0fk03a0hxoo0" path="res://core/effects/card_effect.gd" id="1_kgdkh"]
 
 [resource]
 script = ExtResource("1_card_data")
@@ -8,4 +9,3 @@ name = "Defend"
 cost = 1
 description = "Gain 5 shield. (Placeholder until #7.)"
 target_type = 1
-effects = Array[Resource]([])

--- a/content/cards/strike.tres
+++ b/content/cards/strike.tres
@@ -1,12 +1,11 @@
 [gd_resource type="Resource" script_class="CardData" format=3 uid="uid://b3strike0001"]
 
+[ext_resource type="Script" uid="uid://c0fk03a0hxoo0" path="res://core/effects/card_effect.gd" id="1_7mg6n"]
 [ext_resource type="Script" uid="uid://dj0q6jkwgu5ar" path="res://core/cards/card_data.gd" id="1_card_data"]
 [ext_resource type="Script" uid="uid://bwmuqgefbptdl" path="res://core/effects/damage_effect.gd" id="2_damage_effect"]
 
 [sub_resource type="Resource" id="Resource_strike_damage"]
 script = ExtResource("2_damage_effect")
-affects = 0
-trigger = 0
 amount = 6
 
 [resource]
@@ -15,4 +14,4 @@ name = "Strike"
 cost = 1
 description = "Deal 6 damage."
 target_type = 0
-effects = Array[Resource]([SubResource("Resource_strike_damage")])
+effects = Array[ExtResource("1_7mg6n")]([SubResource("Resource_strike_damage")])

--- a/core/battle/battle_controller.gd
+++ b/core/battle/battle_controller.gd
@@ -22,6 +22,7 @@ func _init() -> void:
 func run_battle() -> void:
 	events.dispatch(BattleStartedEvent.new())
 	while not _battle_end_pending:
+		state.refresh_energy()
 		state.draw(STARTING_HAND_SIZE)
 		await end_turn_requested
 		state.discard_hand()

--- a/core/battle/battle_state.gd
+++ b/core/battle/battle_state.gd
@@ -13,6 +13,9 @@ var hand: Array[CardInstance] = []
 var discard: Array[CardInstance] = []
 var exhaust: Array[CardInstance] = []
 
+var energy_current: int = 3
+var energy_max: int = 3
+
 var rng: RandomNumberGenerator = RandomNumberGenerator.new()
 
 
@@ -49,6 +52,16 @@ func discard_hand() -> void:
 
 func _notify_hand_changed() -> void:
 	events.dispatch(HandChangedEvent.new())
+
+
+func spend_energy(amount: int) -> void:
+	energy_current -= amount
+	events.dispatch(EnergyChangedEvent.new())
+
+
+func refresh_energy() -> void:
+	energy_current = energy_max
+	events.dispatch(EnergyChangedEvent.new())
 
 
 func draw(count: int) -> void:

--- a/core/battle/energy_changed_event.gd
+++ b/core/battle/energy_changed_event.gd
@@ -1,0 +1,2 @@
+class_name EnergyChangedEvent
+extends BattleEvent

--- a/core/battle/energy_changed_event.gd.uid
+++ b/core/battle/energy_changed_event.gd.uid
@@ -1,0 +1,1 @@
+uid://d3ew2onaeravo

--- a/core/cards/card_instance.gd
+++ b/core/cards/card_instance.gd
@@ -12,3 +12,7 @@ func _init(card_data: CardData) -> void:
 func play(battle: BattleState, target: Character) -> void:
 	for effect: CardEffect in data.effects:
 		effect.apply(battle, battle.player, target)
+
+
+func can_play(battle: BattleState) -> bool:
+	return data.cost <= battle.energy_current

--- a/tests/battle/test_battle_controller.gd
+++ b/tests/battle/test_battle_controller.gd
@@ -93,6 +93,25 @@ func test_multi_turn_cycling_drives_deck_through_hand_discard_and_reshuffle() ->
 	await wait_physics_frames(1)
 
 
+func test_run_battle_refreshes_energy_at_the_start_of_each_player_turn() -> void:
+	var controller: BattleController = _make_controller_with_battle()
+	_seed_deck(controller, 12)
+
+	controller.run_battle.call()
+	controller.state.spend_energy(2)
+	var mid_turn_energy: int = controller.state.energy_current
+	assert_eq(mid_turn_energy, 1, "spending 2 mid-turn should leave 1 energy before next refresh")
+
+	controller.request_end_turn()
+	await wait_physics_frames(1)
+
+	var refreshed_energy: int = controller.state.energy_current
+	assert_eq(refreshed_energy, controller.state.energy_max, "the next player turn should start at full energy")
+
+	controller.request_battle_end()
+	await wait_physics_frames(1)
+
+
 func test_request_battle_end_resumes_run_battle_and_dispatches_battle_ended() -> void:
 	var controller: BattleController = _make_controller_with_battle()
 

--- a/tests/battle/test_battle_state.gd
+++ b/tests/battle/test_battle_state.gd
@@ -197,6 +197,33 @@ func test_discard_hand_moves_every_remaining_hand_card_to_discard_in_order() -> 
 	assert_eq(battle.discard, [first, second, third] as Array[CardInstance], "all cards should land on discard preserving hand order")
 
 
+func _watch_energy_changes(battle: BattleState) -> Array[BattleEvent]:
+	var received: Array[BattleEvent] = []
+	var listener: Callable = func(event: BattleEvent) -> void:
+		received.append(event)
+	var _sub: EventSubscription = battle.events.subscribe(EnergyChangedEvent, listener, 0)
+	return received
+
+
+func test_spend_energy_dispatches_an_energy_changed_event() -> void:
+	var battle: BattleState = _make_battle()
+	var observed: Array[BattleEvent] = _watch_energy_changes(battle)
+
+	battle.spend_energy(1)
+
+	assert_eq(observed.size(), 1, "spending energy should dispatch exactly one EnergyChangedEvent")
+
+
+func test_refresh_energy_dispatches_an_energy_changed_event() -> void:
+	var battle: BattleState = _make_battle()
+	battle.spend_energy(2)
+	var observed: Array[BattleEvent] = _watch_energy_changes(battle)
+
+	battle.refresh_energy()
+
+	assert_eq(observed.size(), 1, "refreshing energy should dispatch exactly one EnergyChangedEvent")
+
+
 func _watch_hand_changes(battle: BattleState) -> Array[BattleEvent]:
 	var received: Array[BattleEvent] = []
 	var listener: Callable = func(event: BattleEvent) -> void:
@@ -235,6 +262,35 @@ func test_exhaust_from_hand_dispatches_a_hand_changed_event() -> void:
 	battle.exhaust_from_hand(card)
 
 	assert_eq(observed.size(), 1, "exhausting from hand should dispatch a HandChangedEvent")
+
+
+func test_battle_state_starts_with_three_energy_out_of_three() -> void:
+	var battle: BattleState = _make_battle()
+
+	var current: int = battle.energy_current
+	var maximum: int = battle.energy_max
+	assert_eq(current, 3, "energy_current should start at the 3-energy turn budget")
+	assert_eq(maximum, 3, "energy_max should start at 3 (no carry-over budget)")
+
+
+func test_spend_energy_subtracts_amount_from_energy_current() -> void:
+	var battle: BattleState = _make_battle()
+
+	battle.spend_energy(2)
+
+	var current: int = battle.energy_current
+	assert_eq(current, 1, "spending 2 of 3 energy should leave 1")
+
+
+func test_refresh_energy_restores_energy_current_to_energy_max() -> void:
+	var battle: BattleState = _make_battle()
+	battle.spend_energy(3)
+
+	battle.refresh_energy()
+
+	var current: int = battle.energy_current
+	var maximum: int = battle.energy_max
+	assert_eq(current, maximum, "refresh should fill energy_current back to energy_max")
 
 
 func test_discard_hand_dispatches_a_single_hand_changed_event_for_the_whole_batch() -> void:

--- a/tests/cards/test_card_instance.gd
+++ b/tests/cards/test_card_instance.gd
@@ -42,6 +42,34 @@ func test_play_invokes_each_effect_apply_with_battle_player_and_target() -> void
 	assert_same(second.last_target, enemy, "every effect should see the played-against target")
 
 
+func test_can_play_is_true_when_card_cost_equals_current_energy() -> void:
+	var player: Character = Character.new(40)
+	var enemy: Character = Character.new(18)
+	var battle: BattleState = _make_battle(player, [enemy] as Array[Character])
+	battle.spend_energy(2)
+
+	var data: CardData = CardData.new()
+	data.cost = 1
+	var card: CardInstance = CardInstance.new(data)
+
+	var result: bool = card.can_play(battle)
+	assert_true(result, "a 1-cost card with exactly 1 energy remaining should be playable")
+
+
+func test_can_play_is_false_when_card_cost_exceeds_current_energy() -> void:
+	var player: Character = Character.new(40)
+	var enemy: Character = Character.new(18)
+	var battle: BattleState = _make_battle(player, [enemy] as Array[Character])
+	battle.spend_energy(2)
+
+	var data: CardData = CardData.new()
+	data.cost = 2
+	var card: CardInstance = CardInstance.new(data)
+
+	var result: bool = card.can_play(battle)
+	assert_false(result, "a 2-cost card should not be playable when only 1 energy remains")
+
+
 func test_play_strike_drops_enemy_hp_through_the_full_pipeline() -> void:
 	var player: Character = Character.new(40)
 	var enemy: Character = Character.new(18)

--- a/ui/battle/battle_scene.gd
+++ b/ui/battle/battle_scene.gd
@@ -11,6 +11,7 @@ const DEFEND: CardData = preload("res://content/cards/defend.tres")
 @onready var _hand_ui: HandUI = $HandUI
 @onready var _deck_count_label: Label = $DeckCount
 @onready var _discard_count_label: Label = $DiscardCount
+@onready var _energy_orb: EnergyOrb = $EnergyOrb
 
 var _state: BattleState
 var _enemy: Character
@@ -30,6 +31,7 @@ func _ready() -> void:
 	_enemy_view.bind(_enemy, _controller.events)
 
 	_hand_ui.bind(_state, _player_view, [_enemy_view] as Array[CharacterView])
+	_energy_orb.bind(_state)
 
 	_hand_subscription = _controller.events.subscribe(HandChangedEvent, _on_hand_changed, 0)
 	_end_turn_button.pressed.connect(_on_end_turn_pressed)

--- a/ui/battle/battle_scene.tscn
+++ b/ui/battle/battle_scene.tscn
@@ -1,20 +1,20 @@
-[gd_scene load_steps=6 format=3 uid="uid://cvii3mt1lge1a"]
+[gd_scene format=3 uid="uid://cvii3mt1lge1a"]
 
 [ext_resource type="Script" uid="uid://1ldedv020xmp" path="res://ui/battle/battle_scene.gd" id="1_battle_scene"]
 [ext_resource type="Script" uid="uid://cjjxakg20v6sm" path="res://core/battle/battle_controller.gd" id="2_battle_controller"]
 [ext_resource type="PackedScene" uid="uid://cfflio10r24jw" path="res://ui/battle/character_view.tscn" id="3_character_view"]
-[ext_resource type="PackedScene" uid="uid://b4handui0001" path="res://ui/battle/hand_ui.tscn" id="4_hand_ui"]
-[ext_resource type="Script" path="res://core/cards/hand_layout_params.gd" id="5_hand_layout_params"]
+[ext_resource type="PackedScene" path="res://ui/battle/hand_ui.tscn" id="4_hand_ui"]
+[ext_resource type="Script" uid="uid://vfng1fj5cfpc" path="res://core/cards/hand_layout_params.gd" id="5_hand_layout_params"]
+[ext_resource type="PackedScene" path="res://ui/battle/energy_orb.tscn" id="6_energy_orb"]
 
 [sub_resource type="Resource" id="HandLayoutParams_default"]
 script = ExtResource("5_hand_layout_params")
 arc_radius = 1400.0
 total_fan_angle_deg = 32.0
 hover_lift = 100.0
-hover_scale = 1.18
 neighbor_displacement = 60.0
 
-[node name="BattleScene" type="Control"]
+[node name="BattleScene" type="Control" unique_id=888749942]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -23,10 +23,10 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_battle_scene")
 
-[node name="BattleController" type="Node" parent="."]
+[node name="BattleController" type="Node" parent="." unique_id=1298925719]
 script = ExtResource("2_battle_controller")
 
-[node name="Stage" type="HBoxContainer" parent="."]
+[node name="Stage" type="HBoxContainer" parent="." unique_id=315418188]
 layout_mode = 1
 anchors_preset = 10
 anchor_right = 1.0
@@ -35,16 +35,16 @@ offset_top = 40.0
 offset_right = -40.0
 offset_bottom = 200.0
 grow_horizontal = 2
-alignment = 1
 theme_override_constants/separation = 200
+alignment = 1
 
-[node name="PlayerView" parent="Stage" instance=ExtResource("3_character_view")]
+[node name="PlayerView" parent="Stage" unique_id=2114949298 instance=ExtResource("3_character_view")]
 layout_mode = 2
 
-[node name="EnemyView" parent="Stage" instance=ExtResource("3_character_view")]
+[node name="EnemyView" parent="Stage" unique_id=149560493 instance=ExtResource("3_character_view")]
 layout_mode = 2
 
-[node name="EndTurnButton" type="Button" parent="."]
+[node name="EndTurnButton" type="Button" parent="." unique_id=908655730]
 layout_mode = 1
 anchors_preset = 6
 anchor_left = 1.0
@@ -59,7 +59,7 @@ grow_horizontal = 0
 grow_vertical = 2
 text = "End Turn (Space)"
 
-[node name="DeckCount" type="Label" parent="."]
+[node name="DeckCount" type="Label" parent="." unique_id=987710419]
 layout_mode = 1
 anchors_preset = 2
 anchor_top = 1.0
@@ -71,32 +71,44 @@ offset_bottom = -24.0
 grow_vertical = 0
 text = "Deck: 0"
 
-[node name="DiscardCount" type="Label" parent="."]
+[node name="DiscardCount" type="Label" parent="." unique_id=484081958]
 layout_mode = 1
 anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -160.0
+offset_left = -260.0
 offset_top = -56.0
-offset_right = -24.0
+offset_right = -124.0
 offset_bottom = -24.0
 grow_horizontal = 0
 grow_vertical = 0
-horizontal_alignment = 2
 text = "Discard: 0"
+horizontal_alignment = 2
 
-[node name="HandUI" parent="." instance=ExtResource("4_hand_ui")]
+[node name="EnergyOrb" parent="." unique_id=615644285 instance=ExtResource("6_energy_orb")]
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -104.0
+offset_top = -96.0
+offset_right = -32.0
+offset_bottom = -24.0
+grow_horizontal = 0
+grow_vertical = 0
+
+[node name="HandUI" parent="." unique_id=1988631046 instance=ExtResource("4_hand_ui")]
 layout_mode = 1
 anchors_preset = 7
 anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
 anchor_bottom = 1.0
-offset_left = 0.0
 offset_top = -200.0
-offset_right = 0.0
 offset_bottom = -200.0
 grow_horizontal = 2
 grow_vertical = 0

--- a/ui/battle/card_view.gd
+++ b/ui/battle/card_view.gd
@@ -7,6 +7,8 @@ signal hover_exited_card(card_view: CardView)
 signal pressed_card(card_view: CardView, mouse_global_position: Vector2)
 
 const CARD_SIZE: Vector2 = Vector2(140, 200)
+const AFFORDABLE_MODULATE: Color = Color(1.0, 1.0, 1.0, 1.0)
+const UNAFFORDABLE_MODULATE: Color = Color(1.0, 0.55, 0.55, 0.7)
 
 var card_instance: CardInstance
 
@@ -47,6 +49,10 @@ func snap_to_position(top_left: Vector2) -> void:
 
 func center_position() -> Vector2:
 	return position + pivot_offset
+
+
+func set_affordable(affordable: bool) -> void:
+	modulate = AFFORDABLE_MODULATE if affordable else UNAFFORDABLE_MODULATE
 
 
 func _refresh() -> void:

--- a/ui/battle/energy_orb.gd
+++ b/ui/battle/energy_orb.gd
@@ -1,0 +1,32 @@
+class_name EnergyOrb
+extends Control
+
+
+@onready var _value_label: Label = $Value
+
+var _state: BattleState
+var _subscription: EventSubscription
+
+
+func _exit_tree() -> void:
+	if _subscription != null:
+		_subscription.release()
+		_subscription = null
+
+
+func bind(state: BattleState) -> void:
+	_state = state
+	if _subscription != null:
+		_subscription.release()
+	_subscription = _state.events.subscribe(EnergyChangedEvent, _on_energy_changed, 0)
+	_refresh()
+
+
+func _on_energy_changed(_event: BattleEvent) -> void:
+	_refresh()
+
+
+func _refresh() -> void:
+	if _state == null or _value_label == null:
+		return
+	_value_label.text = "%d/%d" % [_state.energy_current, _state.energy_max]

--- a/ui/battle/energy_orb.gd.uid
+++ b/ui/battle/energy_orb.gd.uid
@@ -1,0 +1,1 @@
+uid://c41nctkia62ty

--- a/ui/battle/energy_orb.tscn
+++ b/ui/battle/energy_orb.tscn
@@ -1,0 +1,42 @@
+[gd_scene format=3 uid="uid://b4energyorb01"]
+
+[ext_resource type="Script" path="res://ui/battle/energy_orb.gd" id="1_energy_orb"]
+
+[node name="EnergyOrb" type="Control"]
+custom_minimum_size = Vector2(72, 72)
+script = ExtResource("1_energy_orb")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.196078, 0.156863, 0.305882, 1)
+
+[node name="Border" type="ReferenceRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+border_color = Color(1, 0.85098, 0.34902, 1)
+border_width = 3.0
+editor_only = false
+
+[node name="Value" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme_override_colors/font_color = Color(1, 0.85098, 0.34902, 1)
+theme_override_font_sizes/font_size = 22
+text = "3/3"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/ui/battle/hand_ui.gd
+++ b/ui/battle/hand_ui.gd
@@ -16,6 +16,7 @@ const DRAG_THRESHOLD_PX: float = 6.0
 var _state: BattleState
 var _enemy_views: Array[CharacterView] = []
 var _player_view: CharacterView
+var _energy_subscription: EventSubscription
 
 var _card_views: Array[CardView] = []
 var _hovered_index: int = -1
@@ -39,6 +40,19 @@ func bind(state: BattleState, player_view: CharacterView, enemy_views: Array[Cha
 	_state = state
 	_player_view = player_view
 	_enemy_views = enemy_views
+	if _energy_subscription != null:
+		_energy_subscription.release()
+	_energy_subscription = _state.events.subscribe(EnergyChangedEvent, _on_energy_changed, 0)
+
+
+func _exit_tree() -> void:
+	if _energy_subscription != null:
+		_energy_subscription.release()
+		_energy_subscription = null
+
+
+func _on_energy_changed(_event: BattleEvent) -> void:
+	_refresh_affordability()
 
 
 func render(hand: Array[CardInstance]) -> void:
@@ -59,6 +73,14 @@ func render(hand: Array[CardInstance]) -> void:
 		add_child(view)
 		_card_views.append(view)
 	_apply_layout(false)
+	_refresh_affordability()
+
+
+func _refresh_affordability() -> void:
+	if _state == null:
+		return
+	for view: CardView in _card_views:
+		view.set_affordable(_can_afford(view.card_instance))
 
 
 func _apply_layout(animate: bool) -> void:
@@ -146,27 +168,36 @@ func _resolve_release(release_global_position: Vector2) -> void:
 		_apply_layout(true)
 		return
 	var played: bool = false
-	if _drag_is_targeted:
-		var enemy: Character = _enemy_under(release_global_position)
-		if enemy != null:
-			_commit_play(dragged_view.card_instance, enemy)
-			played = true
-	else:
-		var card_top_global: float = dragged_view.global_position.y
-		var threshold_global_y: float = global_position.y + nontargeted_play_threshold_offset_y
-		if card_top_global <= threshold_global_y and _state != null:
-			_commit_play(dragged_view.card_instance, _state.player)
-			played = true
+	if _can_afford(dragged_view.card_instance):
+		if _drag_is_targeted:
+			var enemy: Character = _enemy_under(release_global_position)
+			if enemy != null:
+				_commit_play(dragged_view.card_instance, enemy)
+				played = true
+		else:
+			var card_top_global: float = dragged_view.global_position.y
+			var threshold_global_y: float = global_position.y + nontargeted_play_threshold_offset_y
+			if card_top_global <= threshold_global_y and _state != null:
+				_commit_play(dragged_view.card_instance, _state.player)
+				played = true
 	if played:
 		return
 	_dragged_index = -1
 	_apply_layout(true)
 
 
+func _can_afford(card_instance: CardInstance) -> bool:
+	if _state == null or card_instance == null:
+		return false
+	return card_instance.can_play(_state)
+
+
 func _commit_play(card_instance: CardInstance, target: Character) -> void:
 	if _state == null:
 		return
+	var cost: int = card_instance.data.cost
 	card_instance.play(_state, target)
+	_state.spend_energy(cost)
 	_state.discard_from_hand(card_instance)
 	card_play_committed.emit(card_instance, target)
 


### PR DESCRIPTION
Closes #6.

## Summary

- `BattleState` tracks `energy_current`/`energy_max` (3/3) with `spend_energy()` and `refresh_energy()`, both dispatching a new `EnergyChangedEvent`.
- `BattleController.run_battle` refreshes energy at the start of each player turn.
- `CardInstance.can_play(battle)` is the affordability check. `HandUI` rejects drag commits when a card is unaffordable and deducts `cost` immediately on commit.
- `CardView.set_affordable()` red-tints + dims unaffordable cards. `HandUI` re-applies on every `EnergyChangedEvent`.
- New `EnergyOrb` Control (and `.tscn`) bottom-far-right beside the discard label, listening to `EnergyChangedEvent`.

## Test plan

- [x] `godot --headless ... gut_cmdln.gd` — 65/65 passing
- [x] Open the scene in editor: 3/3 orb shows on turn start
- [x] Play a 1-cost card → orb updates same-frame to 2/3
- [x] Spend all 3 energy, verify remaining hand cards visibly dim/redden and refuse to commit on drag
- [x] End turn → orb refreshes to 3/3 and cards regain full opacity

## Out of scope (deferred)

- End Turn button disabled during enemy turn — depends on #8 (no enemy turn exists yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)